### PR TITLE
Fix mapCanvas overflow clipping absolutely-positioned tree nodes

### DIFF
--- a/backend/src/virtualRenderer/LayoutGenerator/pages/debatePage/FullDebateView/FullDebatePageGenerator.cc
+++ b/backend/src/virtualRenderer/LayoutGenerator/pages/debatePage/FullDebateView/FullDebatePageGenerator.cc
@@ -2655,6 +2655,7 @@ ui::Component FullDebatePageGenerator::GenerateMapSection(const rendering_info::
     );
     (*mapCanvas.mutable_css())["width"] = std::to_string(canvasWidth) + "px";
     (*mapCanvas.mutable_css())["height"] = std::to_string(canvasHeight) + "px";
+    (*mapCanvas.mutable_css())["overflow"] = "visible";
     (*mapCanvas.mutable_css())["transform"] = "scale(" + std::to_string(normalizedScale) + ")";
     (*mapCanvas.mutable_css())["transform-origin"] = "top left";
 

--- a/frontend/src/display/rendering/componentTypes/ContainerComponent.tsx
+++ b/frontend/src/display/rendering/componentTypes/ContainerComponent.tsx
@@ -19,7 +19,7 @@ const ContainerComponent: React.FC<BaseComponentProps> = ({ component, className
           gap: '0.75rem',
         } : {}),
         ...style,
-        overflow: 'hidden',
+        overflow: style?.overflow || 'hidden',
       }}
     >
       {nested.map((child: any, idx: number) => (


### PR DESCRIPTION
- ContainerComponent: inline style overflow now overrides default (was always hidden)
- FullDebatePageGenerator: set mapCanvas overflow=visible so tree edges/nodes are not clipped by the canvas container base styles